### PR TITLE
Fixing Delphi XE compatibility

### DIFF
--- a/src/GpHugeF.pas
+++ b/src/GpHugeF.pas
@@ -870,7 +870,7 @@ uses
   GpLogger,
   {$ENDIF UseLogger}
   GpLists,
-  System.Types;
+  Types;
 
 const
   //:Default buffer size. 64 KB, small enough to be VirtualLock'd in NT 4


### PR DESCRIPTION
There are no namespaces in Delphi sources prior to XE2