### PR TITLE
improve: GpCommandLineParser: allow to restrict for assign published properties only

### DIFF
--- a/src/GpCommandLineParser.pas
+++ b/src/GpCommandLineParser.pas
@@ -199,7 +199,7 @@ type
     Text      : string;
   end; { TCLPErrorInfo }
 
-  TCLPOption = (opIgnoreUnknownSwitches);
+  TCLPOption = (opIgnoreUnknownSwitches, opPublishedPropertiesOnly);
   TCLPOptions = set of TCLPOption;
 
   IGpCommandLineParser = interface ['{C9B729D4-3706-46DB-A8A2-1E07E04F497B}']
@@ -921,7 +921,9 @@ begin
   typ := ctx.GetType(commandData.ClassType);
   for prop in typ.GetProperties do
     if prop.Parent = typ then
-      ProcessAttributes(commandData, prop);
+      if not (opPublishedPropertiesOnly in FOptions)
+          or (prop.Visibility = TMemberVisibility.mvPublished) then
+        ProcessAttributes(commandData, prop);
 end; { TGpCommandLineParser.ProcessDefinitionClass }
 
 function TGpCommandLineParser.SetError(kind: TCLPErrorKind; detail: TCLPErrorDetailed;


### PR DESCRIPTION
Sometimes a target class can have a public property of a custom
enumeration type which is set from a string value from a command line.
E.g.
  type
    TLogLevel = (llTrace, llDebug, ...

    TCommandLine = class
    private
      FLogLevel: TLogLevel
    public
      property LogLevel: TLogLevel read FLogLevel write FLogLevel;

      [CLPLongName('log-level')]
      property LogLevelAsStr: string read GetLogLevelAsStr write SetLogLevelAsStr;
    end;

In this case TGpCommandLineParser raises the SUnsupportedPropertyType
exception for LogLevel property as it supports Integer, String and
Boolean types only.

Let's fix it by adding opPublishedPropertiesOnly option to tell a parser
to respect published properties only.
So, TCommandLine will appear to be defined as the following

    TCommandLine = class
    private
      FLogLevel: TLogLevel
    public
      property LogLevel: TLogLevel read FLogLevel write FLogLevel;
    published
      [CLPLongName('log-level')]
      property LogLevelAsStr: string read GetLogLevelAsStr write SetLogLevelAsStr;
    end;